### PR TITLE
Tweak build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Postcoder](https://travis-ci.org/fivegoodfriends/postcoder) ![Travis CI build status](https://travis-ci.org/fivegoodfriends/postcoder.svg?branch=master)
+# Postcoder [![Travis CI build status](https://travis-ci.org/fivegoodfriends/postcoder.svg?branch=master)](https://travis-ci.org/fivegoodfriends/postcoder)
 
 Microservice to return surrounding postcodes given an Australian postcode.
 Leverages the `australia_postcode` gem. All distance calculations are performed


### PR DESCRIPTION
- Make the build badge link to the Travis CI page for the repo