### PR TITLE
Automatic deploys to production + Buildkite

### DIFF
--- a/.buildkite/deploy.yml
+++ b/.buildkite/deploy.yml
@@ -1,3 +1,0 @@
----
-- name: ":heroku: Deploy"
-  command: "./script/deploy"

--- a/.buildkite/deploy.yml
+++ b/.buildkite/deploy.yml
@@ -1,0 +1,3 @@
+---
+- name: ":heroku: Deploy"
+  command: "./script/deploy"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,8 @@
+---
+- name: ":rspec: CI"
+  command: "./script/ci"
+  agents:
+    ruby: "2.5.1"
+- name: ":heroku: Deploy"
+  command: "./script/deploy"
+  branches: "master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-env:
-  - API_TOKEN=EXAMPLETOKEN1
-script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Postcoder [![Travis CI build status](https://travis-ci.org/fivegoodfriends/postcoder.svg?branch=master)](https://travis-ci.org/fivegoodfriends/postcoder)
+# Postcoder [![Build status](https://badge.buildkite.com/e4df0912e62c296fba88d74ee6b8d04b4b641cd7c7a04fdb31.svg)](https://buildkite.com/fivegoodfriends/postcoder)
 
 Microservice to return surrounding postcodes given an Australian postcode.
 Leverages the `australia_postcode` gem. All distance calculations are performed

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+export DISABLE_SPRING='true'
+export RAILS_ENV='test'
+
+source .envrc
+
+echo '--- bundling'
+bundle check || bundle install --path vendor/bundle
+
+echo '--- specs'
+bundle exec rspec

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+USAGE="usage: ./deploy"
+
+echo "--- Deploying to $HEROKU_APP_NAME"
+if [ "$(git remote | grep $HEROKU_APP_NAME)" = $HEROKU_APP_NAME ]; then
+  git remote remove $HEROKU_APP_NAME
+fi
+git remote add $HEROKU_APP_NAME "https://git.heroku.com/$HEROKU_APP_NAME.git"
+git push --force $HEROKU_APP_NAME "$BUILDKITE_COMMIT":master


### PR DESCRIPTION
I have a threshold of being annoyed about 3-4 times before I do something about it. In this case it's automatically deploying to master after specs pass. This should make future dependabot updates a breeze.

Why this setup?

- We use Buildkite for the main app. There's less churning if we use the same tools we're already familiar with. All the bot users have been setup, deployment keys are already configured, etc, etc.
- Third party forks are disabled so people can't arbitrarily execute code on our CI boxes. Downside is that we'll need to pull down contributions and run them ourselves.

Was anything else considered?

- Yes, I initially tried to make the native Heroku <> GitHub integration work. Created a bot user with access to the specific repos and it was failing. Don't want to deal with Heroku support. Plus, more tools to worry about.
- Could continue with Travis, but again, would rather just standardise on Buildkite